### PR TITLE
Add fee events in vault mix and tests

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -124,6 +124,13 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
 
     // Emitted during a report, when there has been an increase in pricePerFullShare (ppfs)
     event Harvested(address indexed token, uint256 amount, uint256 indexed blockNumber, uint256 timestamp);
+    event PerformanceFeeGovernance(
+        address indexed destination,
+        address indexed token,
+        uint256 amount,
+        uint256 indexed blockNumber,
+        uint256 timestamp
+    );
 
     event SetTreasury(address indexed newTreasury);
     event SetStrategy(address indexed newStrategy);
@@ -407,7 +414,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
 
         if(governanceRewardsFee != 0) {
             IERC20Upgradeable(_token).safeTransfer(treasury, governanceRewardsFee);
-
+            emit PerformanceFeeGovernance(treasury, _token, governanceRewardsFee, block.number, block.timestamp);
         }
 
         if(strategistRewardsFee != 0) {
@@ -807,6 +814,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         // uint != is cheaper and equivalent to >
         if (totalGovernanceFee != 0) {
             _mintSharesFor(treasury, totalGovernanceFee, _pool);
+            emit PerformanceFeeGovernance(treasury, address(this), totalGovernanceFee, block.number, block.timestamp);
         }
 
         if (feeStrategist != 0 && strategist != address(0)) {

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -836,7 +836,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         if (feeStrategist != 0 && strategist != address(0)) {
             /// NOTE: adding feeGovernance backed to _pool as shares would have been issued for it.
             _mintSharesFor(strategist, feeStrategist, _pool.add(totalGovernanceFee));
-            emit PerformanceFeeStrategist(strategist, _token, feeStrategist, block.number, block.timestamp);
+            emit PerformanceFeeStrategist(strategist, address(this), feeStrategist, block.number, block.timestamp);
         }
     }
 }

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -138,7 +138,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         uint256 indexed blockNumber,
         uint256 timestamp
     );
-    event WithdrawFee(
+    event WithdrawalFee(
         address indexed destination,
         address indexed token,
         uint256 amount,
@@ -759,7 +759,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         // Process withdrawal fee
         if(_fee > 0) {
             _mintSharesFor(treasury, _fee, balance().sub(_fee));
-            emit WithdrawFee(treasury, address(this), _fee, block.number, block.timestamp);
+            emit WithdrawalFee(treasury, address(this), _fee, block.number, block.timestamp);
         }
     }
 

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -131,6 +131,20 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         uint256 indexed blockNumber,
         uint256 timestamp
     );
+    event PerformanceFeeStrategist(
+        address indexed destination,
+        address indexed token,
+        uint256 amount,
+        uint256 indexed blockNumber,
+        uint256 timestamp
+    );
+    event WithdrawFee(
+        address indexed destination,
+        address indexed token,
+        uint256 amount,
+        uint256 indexed blockNumber,
+        uint256 timestamp
+    );
 
     event SetTreasury(address indexed newTreasury);
     event SetStrategy(address indexed newStrategy);
@@ -419,6 +433,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
 
         if(strategistRewardsFee != 0) {
             IERC20Upgradeable(_token).safeTransfer(strategist, strategistRewardsFee);
+            emit PerformanceFeeStrategist(strategist, _token, strategistRewardsFee, block.number, block.timestamp);
         }
 
         // Send rest to tree
@@ -744,6 +759,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         // Process withdrawal fee
         if(_fee > 0) {
             _mintSharesFor(treasury, _fee, balance().sub(_fee));
+            emit WithdrawFee(treasury, address(this), _fee, block.number, block.timestamp);
         }
     }
 
@@ -820,6 +836,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         if (feeStrategist != 0 && strategist != address(0)) {
             /// NOTE: adding feeGovernance backed to _pool as shares would have been issued for it.
             _mintSharesFor(strategist, feeStrategist, _pool.add(totalGovernanceFee));
+            emit PerformanceFeeStrategist(strategist, _token, feeStrategist, block.number, block.timestamp);
         }
     }
 }

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -427,13 +427,15 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         uint256 strategistRewardsFee = _calculateFee(tokenBalance, performanceFeeStrategist);
 
         if(governanceRewardsFee != 0) {
-            IERC20Upgradeable(_token).safeTransfer(treasury, governanceRewardsFee);
-            emit PerformanceFeeGovernance(treasury, _token, governanceRewardsFee, block.number, block.timestamp);
+            address cachedTreasury = treasury;
+            IERC20Upgradeable(_token).safeTransfer(cachedTreasury, governanceRewardsFee);
+            emit PerformanceFeeGovernance(cachedTreasury, _token, governanceRewardsFee, block.number, block.timestamp);
         }
 
         if(strategistRewardsFee != 0) {
-            IERC20Upgradeable(_token).safeTransfer(strategist, strategistRewardsFee);
-            emit PerformanceFeeStrategist(strategist, _token, strategistRewardsFee, block.number, block.timestamp);
+            address cachedStrategist = strategist;
+            IERC20Upgradeable(_token).safeTransfer(cachedStrategist, strategistRewardsFee);
+            emit PerformanceFeeStrategist(cachedStrategist, _token, strategistRewardsFee, block.number, block.timestamp);
         }
 
         // Send rest to tree
@@ -758,8 +760,9 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         // After you burned the shares, and you have sent the funds, adding here is equivalent to depositing
         // Process withdrawal fee
         if(_fee > 0) {
-            _mintSharesFor(treasury, _fee, balance().sub(_fee));
-            emit WithdrawalFee(treasury, address(this), _fee, block.number, block.timestamp);
+            address cachedTreasury = treasury;
+            _mintSharesFor(cachedTreasury, _fee, balance().sub(_fee));
+            emit WithdrawalFee(cachedTreasury, address(this), _fee, block.number, block.timestamp);
         }
     }
 
@@ -829,14 +832,16 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
 
         // uint != is cheaper and equivalent to >
         if (totalGovernanceFee != 0) {
-            _mintSharesFor(treasury, totalGovernanceFee, _pool);
-            emit PerformanceFeeGovernance(treasury, address(this), totalGovernanceFee, block.number, block.timestamp);
+            address cachedTreasury = treasury;
+            _mintSharesFor(cachedTreasury, totalGovernanceFee, _pool);
+            emit PerformanceFeeGovernance(cachedTreasury, address(this), totalGovernanceFee, block.number, block.timestamp);
         }
 
         if (feeStrategist != 0 && strategist != address(0)) {
             /// NOTE: adding feeGovernance backed to _pool as shares would have been issued for it.
-            _mintSharesFor(strategist, feeStrategist, _pool.add(totalGovernanceFee));
-            emit PerformanceFeeStrategist(strategist, address(this), feeStrategist, block.number, block.timestamp);
+            address cachedStrategist = strategist;
+            _mintSharesFor(cachedStrategist, feeStrategist, _pool.add(totalGovernanceFee));
+            emit PerformanceFeeStrategist(cachedStrategist, address(this), feeStrategist, block.number, block.timestamp);
         }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,16 @@ def want(deployed):
 
 
 @pytest.fixture
+def token_not_want(deployer):
+    # use for testing `_processExtraToken`
+    token = MockToken.deploy({"from": deployer})
+
+    token.initialize([deployer.address], [100e18])
+
+    return token
+
+
+@pytest.fixture
 def tokens(deployed):
     return [deployed.want]
 

--- a/tests/unit/events/test_fee_events.py
+++ b/tests/unit/events/test_fee_events.py
@@ -1,0 +1,117 @@
+from helpers.time import days
+from helpers.utils import approx
+
+
+def test_withdrawal_fee_event(vault, want, deployer, governance):
+    depositAmount = int(want.balanceOf(deployer) * 0.1)
+    want.approve(vault.address, depositAmount, {"from": deployer})
+    vault.deposit(depositAmount, {"from": deployer})
+    vault.earn({"from": governance})
+
+    # internally will trigger _withdraw which contains target event
+    withdraw_amount = depositAmount // 10
+    tx = vault.withdraw(withdraw_amount, {"from": deployer})
+
+    wd_fee_event = tx.events["WithdrawalFee"]
+
+    # only one should be emitted
+    assert len(wd_fee_event) == 1
+    # check event fields are expected values (except ts and block)
+    assert wd_fee_event["destination"] == governance
+    assert wd_fee_event["token"] == vault.address
+    assert (
+        wd_fee_event["amount"]
+        == vault.withdrawalFee() * withdraw_amount / vault.MAX_BPS()
+    )
+
+
+def test_perf_fee_gov_event(
+    deployer,
+    vault,
+    strategy,
+    want,
+    token_not_want,
+    governance,
+    strategist,
+    keeper,
+    chain,
+):
+    # include one `deposit`
+    depositAmount = int(want.balanceOf(deployer) * 0.1)
+    want.approve(vault, depositAmount, {"from": deployer})
+    vault.deposit(depositAmount, {"from": deployer})
+
+    chain.sleep(days(1))
+    chain.mine()
+
+    vault.earn({"from": keeper})
+
+    chain.sleep(days(1))
+    chain.mine()
+
+    # needs to leverage these methods from DemoStrategy to trigger events as will do a real strat
+    # check 1st `reportHarvest` route of events emitted in harvest
+    amount_harvested = 1e18
+    prev_harvest_ts = vault.lastHarvestedAt()
+
+    tx = strategy.test_harvest(amount_harvested, {"from": keeper})
+
+    last_harvest_ts = vault.lastHarvestedAt()
+    harvest_duration = last_harvest_ts - prev_harvest_ts
+
+    perf_fee_gov_event = tx.events["PerformanceFeeGovernance"]
+    perf_fee_strategist_event = tx.events["PerformanceFeeStrategist"]
+
+    # since `managementFee` > 0, needs to take into consideration the surplus in the gov fee
+    management_fee = (
+        vault.managementFee()
+        * (vault.balance() - amount_harvested)
+        * harvest_duration
+        / vault.SECS_PER_YEAR()
+        / vault.MAX_BPS()
+    )
+
+    assert len(perf_fee_gov_event) == 1 and len(perf_fee_strategist_event) == 1
+    assert (
+        perf_fee_gov_event["destination"] == governance
+        and perf_fee_strategist_event["destination"] == strategist
+    )
+    assert (
+        perf_fee_gov_event["token"] == vault.address
+        and perf_fee_strategist_event["token"] == vault.address
+    )
+    assert (
+        approx(
+            perf_fee_gov_event["amount"],
+            amount_harvested * vault.performanceFeeGovernance() / vault.MAX_BPS()
+            + management_fee,
+            1,
+        )
+        and perf_fee_strategist_event["amount"]
+        == amount_harvested * vault.performanceFeeStrategist() / vault.MAX_BPS()
+    )
+
+    # chec 2nd `reportAdditionalToken` route of events emitted in harvest
+    token_not_want.transfer(strategy, amount_harvested, {"from": deployer})
+    tx = strategy.test_harvest_only_emit(
+        token_not_want, amount_harvested, {"from": keeper}
+    )
+
+    perf_fee_gov_event = tx.events["PerformanceFeeGovernance"]
+    perf_fee_strategist_event = tx.events["PerformanceFeeStrategist"]
+
+    assert len(perf_fee_gov_event) == 1 and len(perf_fee_strategist_event) == 1
+    assert (
+        perf_fee_gov_event["destination"] == governance
+        and perf_fee_strategist_event["destination"] == strategist
+    )
+    assert (
+        perf_fee_gov_event["token"] == token_not_want.address
+        and perf_fee_strategist_event["token"] == token_not_want.address
+    )
+    assert (
+        perf_fee_gov_event["amount"]
+        == amount_harvested * vault.performanceFeeGovernance() / vault.MAX_BPS()
+        and perf_fee_strategist_event["amount"]
+        == amount_harvested * vault.performanceFeeStrategist() / vault.MAX_BPS()
+    )


### PR DESCRIPTION
This PR has the end goal of adding the right events for anything related with fee rev either for treasury or strategist moving forward. Events added naming: 

- WithdrawalFee
- PerformanceFeeGovernance
- PerformanceFeeStrategist

It also adds a test file ensuring that these events where emitted and captured properly